### PR TITLE
remove deprecated screen_icon()

### DIFF
--- a/mpress-fix-url-references.php
+++ b/mpress-fix-url-references.php
@@ -37,7 +37,6 @@ if ( ! class_exists( 'mPress_Fix_URL_References' ) ) {
 		 */
 		function page_content() { ?>
 			<div class="wrap">
-				<?php screen_icon( 'tools' ); ?>
 				<h2><?php _e( 'mPress Fix URL References', 'mpress-fix-url-references' ); ?></h2>
 				<div class="tool-box"><?php
 					if( ! empty( $_POST['replace_url'] ) && isset( $_POST['nonce'] ) && wp_verify_nonce( $_POST['nonce'], 'fix_url_references' ) ) {


### PR DESCRIPTION
Kind of funny that its deprecated and replaced with a function that later had its functionality removed.

BTW Tested this out and works totally fine with 4.4.1 besides that one function. Not that I was having mixed-content issues on my site or anything...

BTW[] Hi Micah:)
